### PR TITLE
Prevent default on Raycast submenu

### DIFF
--- a/website/components/cmdk/raycast.tsx
+++ b/website/components/cmdk/raycast.tsx
@@ -125,6 +125,7 @@ function SubCommand({
   React.useEffect(() => {
     function listener(e: KeyboardEvent) {
       if (e.key === 'k' && e.metaKey) {
+        e.preventDefault();
         setOpen((o) => !o);
       }
     }


### PR DESCRIPTION
Fixes focusing the address bar in Firefox.