### PR TITLE
Fix textContent not working as expected

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -904,6 +904,7 @@ function useValue(
       }
     })()
 
+    if (typeof value === 'undefined') return
     context.value(id, value)
     ref.current?.setAttribute(VALUE_ATTR, value)
     valueRef.current = value

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -54,6 +54,14 @@ test.describe('basic behavior', async () => {
     await expect(page.locator(`[cmdk-empty]`)).toHaveText('No results.')
   })
 
+  test('items filtered back after the empty component and backspace', async ({ page }) => {
+    const input = page.locator('[cmdk-input]')
+    await input.type('Itemm')
+    await input.press('Backspace')
+    await expect(page.locator(`[cmdk-item]`)).toHaveCount(1)
+    await expect(page.locator(`[cmdk-item][data-value="item"]`)).toHaveText('Item')
+  })
+
   test('className is applied to each part', async ({ page }) => {
     await expect(page.locator(`.root`)).toHaveCount(1)
     await expect(page.locator(`.input`)).toHaveCount(1)

--- a/test/pages/index.tsx
+++ b/test/pages/index.tsx
@@ -8,7 +8,8 @@ const Page = () => {
         <Command.List className="list">
           <Command.Empty className="empty">No results.</Command.Empty>
           <Command.Item onSelect={() => console.log('Item selected')} className="item">
-            Item
+            {/* <span> to force textValue instead of children */}
+            <span>Item</span>
           </Command.Item>
           <Command.Item value="xxx" className="item">
             Value


### PR DESCRIPTION
Fixes #40 

When using textContent instead of value prop, and the element is removed from the dom, useValue sets and returns undefined until the input is empty again.
I added the test to prove the problem.