### PR TITLE
remove dollar sign from code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Demo and examples: [cmdk.paco.me](https://cmdk.paco.me)
 ## Install
 
 ```bash
-$ npm install cmdk
+npm install cmdk
 ```
 
 ## Use


### PR DESCRIPTION
Might want to remove the dollar sign from the `$ npm install cmdk` code snippet since using the copy button next to it copies the whole thing into clipboard which causes errors when pasting into terminals