### PR TITLE
fix(keybinds): `last` fn respects disabled items

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -440,7 +440,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     }
   }
 
-  const last = () => updateSelectedToIndex(state.current.filtered.count - 1)
+  const last = () => updateSelectedToIndex(getValidItems().length - 1)
 
   const next = (e: React.KeyboardEvent) => {
     e.preventDefault()
@@ -593,6 +593,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
   return (
     <div
       ref={mergeRefs([ref, forwardedRef])}
+      id={id}
       {...etc}
       cmdk-item=""
       role="option"

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -593,7 +593,6 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
   return (
     <div
       ref={mergeRefs([ref, forwardedRef])}
-      id={id}
       {...etc}
       cmdk-item=""
       role="option"

--- a/test/keybind.test.ts
+++ b/test/keybind.test.ts
@@ -13,7 +13,7 @@ test.describe('arrow keybinds', async () => {
     await expect(page.locator(`[cmdk-item][aria-selected="true"]`)).toHaveAttribute('data-value', 'first')
   })
 
-  test.only('meta arrow up/down goes to first and last item', async ({ page }) => {
+  test('meta arrow up/down goes to first and last item', async ({ page }) => {
     await expect(page.locator(`[cmdk-item][aria-selected="true"]`)).toHaveAttribute('data-value', 'first')
     await page.locator(`[cmdk-input]`).press('Meta+ArrowDown')
     await expect(page.locator(`[cmdk-item][aria-selected="true"]`)).toHaveAttribute('data-value', 'last')

--- a/test/keybind.test.ts
+++ b/test/keybind.test.ts
@@ -13,7 +13,7 @@ test.describe('arrow keybinds', async () => {
     await expect(page.locator(`[cmdk-item][aria-selected="true"]`)).toHaveAttribute('data-value', 'first')
   })
 
-  test('meta arrow up/down goes to first and last item', async ({ page }) => {
+  test.only('meta arrow up/down goes to first and last item', async ({ page }) => {
     await expect(page.locator(`[cmdk-item][aria-selected="true"]`)).toHaveAttribute('data-value', 'first')
     await page.locator(`[cmdk-input]`).press('Meta+ArrowDown')
     await expect(page.locator(`[cmdk-item][aria-selected="true"]`)).toHaveAttribute('data-value', 'last')

--- a/test/pages/keybinds.tsx
+++ b/test/pages/keybinds.tsx
@@ -9,6 +9,10 @@ const Page = () => {
         <Command.List>
           <Command.Empty>No results.</Command.Empty>
 
+          <Command.Item value="disabled" disabled>
+            Disabled
+          </Command.Item>
+
           <Command.Item value="first">First</Command.Item>
 
           <Command.Group heading="Letters">

--- a/test/pages/keybinds.tsx
+++ b/test/pages/keybinds.tsx
@@ -25,10 +25,15 @@ const Page = () => {
             <Command.Item>Apple</Command.Item>
             <Command.Item>Banana</Command.Item>
             <Command.Item>Orange</Command.Item>
+            <Command.Item disabled>Dragon Fruit</Command.Item>
             <Command.Item>Pear</Command.Item>
           </Command.Group>
 
           <Command.Item value="last">Last</Command.Item>
+
+          <Command.Item value="disabled-3" disabled>
+            Disabled 3
+          </Command.Item>
         </Command.List>
       </Command>
     </div>


### PR DESCRIPTION
# Description

This fixes a bug where if the first Item is `disabled`, <kbd>⌘</kbd>+<kbd>↓</kbd> does not focus the _last_ valid item.