### PR TITLE
arrow keys wrap around

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Or disable filtering and sorting entirely:
 </Command>
 ```
 
+You can make the arrow keys wrap around the list (when you reach the end, it goes back to the first item) by setting the `loop` prop:
+
+<Command loop />
+
 ### Dialog `[cmdk-dialog]` `[cmdk-overlay]`
 
 Props are forwarded to [Command](#command-cmdk-root). Composes Radix UI's Dialog component. The overlay is always rendered. See the [Radix Documentation](https://www.radix-ui.com/docs/primitives/components/dialog) for more information. Can be controlled with the `open` and `onOpenChange` props.

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -426,9 +426,10 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     let newSelected = items[index + change]
 
     if (propsRef.current?.loop) {
-      newSelected = index + change < 0
-        ? items[items.length-1]
-        : index + change === items.length
+      newSelected =
+        index + change < 0
+          ? items[items.length - 1]
+          : index + change === items.length
           ? items[0]
           : items[index + change]
     }

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -70,6 +70,10 @@ type CommandProps = Children &
      * Event handler called when the selected item of the menu changes.
      */
     onValueChange?: (value: string) => void
+    /**
+     * Optionally set to `true` to turn on looping around when using the arrow keys.
+     */
+    loop?: boolean
   }
 
 type Context = {
@@ -419,11 +423,15 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     const index = items.findIndex((item) => item === selected)
 
     // Get item at this index
-    const newSelected = index + change === -1
-      ? items[items.length-1]
-      : index + change === items.length
-        ? items[0]
-        : items[index + change]
+    let newSelected = items[index + change]
+
+    if (propsRef.current?.loop) {
+      newSelected = index + change < 0
+        ? items[items.length-1]
+        : index + change === items.length
+          ? items[0]
+          : items[index + change]
+    }
 
     if (newSelected) store.setState('value', newSelected.getAttribute(VALUE_ATTR))
   }

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -419,7 +419,12 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     const index = items.findIndex((item) => item === selected)
 
     // Get item at this index
-    const newSelected = items[index + change]
+    const newSelected = index + change === -1
+      ? items[items.length-1]
+      : index + change === items.length
+        ? items[0]
+        : items[index + change]
+
     if (newSelected) store.setState('value', newSelected.getAttribute(VALUE_ATTR))
   }
 


### PR DESCRIPTION
Allows the arrow keys to wrap around, so when you press "up" from the input you end up at the bottom item, and when you press down while the last item is selected, it wraps around back to the first item in the list.

Fixes #56.