### PR TITLE
Allow setting a container for Radix.Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,13 @@ return (
 You can provide a `container` prop that accepts an HTML element that is forwarded to Radix UI's Dialog Portal component to specify which element the Dialog should portal into (defaults to `body`). See the [Radix Documentation](https://www.radix-ui.com/docs/primitives/components/dialog#portal) for more information.
 
 ```tsx
-const element = document.querySelector("#container")
+const containerElement = React.useRef(null)
 
 return (
-  <Command.Dialog container={element} />
+  <>
+    <Command.Dialog container={containerElement.current} />
+    <div ref={containerElement} />
+  </>
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ return (
 )
 ```
 
+You can provide a `container` prop that accepts an HTML element that is forwarded to Radix UI's Dialog Portal component to specify which element the Dialog should portal into (defaults to `body`). See the [Radix Documentation](https://www.radix-ui.com/docs/primitives/components/dialog#portal) for more information.
+
+```tsx
+const element = document.querySelector("#container")
+
+return (
+  <Command.Dialog container={element} />
+)
+```
+
 ### Input `[cmdk-input]`
 
 All props are forwarded to the underlying `input` element. Can be controlled with the `value` and `onValueChange` props.

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -14,6 +14,7 @@ type SeparatorProps = DivProps & {
   /** Whether this separator should always be rendered. Useful if you disable automatic filtering. */
   alwaysRender?: boolean
 }
+                   /** `container`: Provide a custom element the Dialog should portal into. */
 type DialogProps = RadixDialog.DialogProps  & CommandProps & { container?: HTMLElement }
 type ListProps = Children & DivProps & {}
 type ItemProps = Children &

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -14,8 +14,8 @@ type SeparatorProps = DivProps & {
   /** Whether this separator should always be rendered. Useful if you disable automatic filtering. */
   alwaysRender?: boolean
 }
-                   /** `container`: Provide a custom element the Dialog should portal into. */
-type DialogProps = RadixDialog.DialogProps  & CommandProps & { container?: HTMLElement }
+/** `container`: Provide a custom element the Dialog should portal into. */
+type DialogProps = RadixDialog.DialogProps & CommandProps & { container?: HTMLElement }
 type ListProps = Children & DivProps & {}
 type ItemProps = Children &
   Omit<DivProps, 'disabled' | 'onSelect' | 'value'> & {

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -14,7 +14,7 @@ type SeparatorProps = DivProps & {
   /** Whether this separator should always be rendered. Useful if you disable automatic filtering. */
   alwaysRender?: boolean
 }
-type DialogProps = RadixDialog.DialogProps & CommandProps
+type DialogProps = RadixDialog.DialogProps  & CommandProps & { container?: HTMLElement }
 type ListProps = Children & DivProps & {}
 type ItemProps = Children &
   Omit<DivProps, 'disabled' | 'onSelect' | 'value'> & {
@@ -750,10 +750,10 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
  * Renders the command menu in a Radix Dialog.
  */
 const Dialog = React.forwardRef<HTMLDivElement, DialogProps>((props, forwardedRef) => {
-  const { open, onOpenChange, ...etc } = props
+  const { open, onOpenChange, container, ...etc } = props
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
-      <RadixDialog.Portal>
+      <RadixDialog.Portal container={container}>
         <RadixDialog.Overlay cmdk-overlay="" />
         <RadixDialog.Content aria-label={props.label} cmdk-dialog="">
           <Command ref={forwardedRef} {...etc} />

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -14,8 +14,11 @@ type SeparatorProps = DivProps & {
   /** Whether this separator should always be rendered. Useful if you disable automatic filtering. */
   alwaysRender?: boolean
 }
-/** `container`: Provide a custom element the Dialog should portal into. */
-type DialogProps = RadixDialog.DialogProps & CommandProps & { container?: HTMLElement }
+type DialogProps = RadixDialog.DialogProps &
+  CommandProps & {
+    /** Provide a custom element the Dialog should portal into. */
+    container?: HTMLElement
+  }
 type ListProps = Children & DivProps & {}
 type ItemProps = Children &
   Omit<DivProps, 'disabled' | 'onSelect' | 'value'> & {


### PR DESCRIPTION
This adds the option to set a `container` prop to `Command.Dialog` that tells `RadixDialog.Portal` to render into a specific element, rather than `body`.