### PR TITLE
Allow keyboard navigation even when text input is not focused

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -475,7 +475,9 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
   return (
     <div
       ref={mergeRefs([ref, forwardedRef])}
+      tabIndex={-1}
       {...etc}
+      style={{ outline: 'none', ...etc.style }}
       cmdk-root=""
       onKeyDown={(e) => {
         etc.onKeyDown?.(e)


### PR DESCRIPTION
### Bug
When the search input is not focused, the navigation keys don't work as expected. In the screencap below, I click elsewhere inside the palette and press the up/down arrow keys, but it scrolls the list/page instead of navigating through the list items.

https://user-images.githubusercontent.com/24620401/199450737-08094588-e54a-40c2-aeb7-56b2b55d654c.mov

### Fix
This fix allows the `cmdk-root` div to capture the navigation keybindings. This also allows the developer to use a custom search input outside the context of `<Command>...</Command>` (which is my use-case 😋)
