### PR TITLE
fix: attempt to prevent exceeding ResizeObserver loop limit

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -738,12 +738,18 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
     if (height.current && ref.current) {
       const el = height.current
       const wrapper = ref.current
+      let animationFrame
       const observer = new ResizeObserver(() => {
-        const height = el.getBoundingClientRect().height
-        wrapper.style.setProperty(`--cmdk-list-height`, height.toFixed(1) + 'px')
+        animationFrame = requestAnimationFrame(() => {
+          const height = el.getBoundingClientRect().height
+          wrapper.style.setProperty(`--cmdk-list-height`, height.toFixed(1) + 'px')
+        })
       })
       observer.observe(el)
-      return () => observer.unobserve(el)
+      return () => {
+        cancelAnimationFrame(animationFrame)
+        observer.unobserve(el)
+      }
     }
   }, [])
 


### PR DESCRIPTION
# Why

Hopefully should fix #64

# How

As stated in the WICG discussion, the workaround to prevent the infinite loops is to call the observer logic within the [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame). 

So, this changeset do just that and adds `cancelAnimationFrame` call to the observer cleanup phase.

# Test Plan

Since I'm not sure how to reproduce this locally I have only run the existing tests and launched website locally to confirm that I cannot spot any regression.