### PR TITLE
Fix Playwright Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       - run: pnpm build
       - run: pnpm test:format
       - run: pnpm playwright install --with-deps
-      - run: pnpm test
+      - run: pnpm test || exit 1
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: playwright-report
-          path: playwright-report
+          path: playwright-report.json

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,9 @@ import { PlaywrightTestConfig, devices } from '@playwright/test'
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? 'github' : 'list',
+  reporter: process.env.CI
+    ? [["github"], ["json", { outputFile: "playwright-report.json" }]]
+    : "list",
   testDir: './test',
   use: {
     trace: 'on-first-retry',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,9 +3,7 @@ import { PlaywrightTestConfig, devices } from '@playwright/test'
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI
-    ? [["github"], ["json", { outputFile: "playwright-report.json" }]]
-    : "list",
+  reporter: process.env.CI ? [['github'], ['json', { outputFile: 'playwright-report.json' }]] : 'list',
   testDir: './test',
   use: {
     trace: 'on-first-retry',


### PR DESCRIPTION
Assuming we want JSON output for Playwright test results. Set up [multiple reporters](https://playwright.dev/docs/test-reporters#multiple-reporters). Also added an `exit 1` if tests fail so if the `pnpm test` step fails (i.e., tests fail), it will exit with a non-zero status code, which will cause the entire job to fail.

Related: https://github.com/pacocoursey/cmdk/issues/24, https://github.com/pacocoursey/cmdk/pull/25

## Current
<img width="1157" alt="CleanShot 2023-02-07 at 20 21 53@2x" src="https://user-images.githubusercontent.com/41944255/217231693-8af5fc89-4086-481e-8e7d-553330c67dc5.png">

## New
<img width="1114" alt="CleanShot 2023-02-07 at 20 19 57@2x" src="https://user-images.githubusercontent.com/41944255/217231697-0d344d3c-b7c1-4843-a783-d010b0eedf38.png">

---

Thanks for the work and setting up such a clean organized project @pacocoursey @raunofreiberg 
