### PR TITLE
Add 'Tab' and 'Shift+Tab' for item navigation

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -465,6 +465,9 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     } else if (e.altKey) {
       // Next group
       updateSelectedToGroup(1)
+    } else if (e.shiftKey) {
+      // Previous item for Shit+Tab
+      updateSelectedByChange(-1)
     } else {
       // Next item
       updateSelectedByChange(1)
@@ -505,6 +508,10 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
               break
             }
             case 'ArrowDown': {
+              next(e)
+              break
+            }
+            case 'Tab': {
               next(e)
               break
             }


### PR DESCRIPTION
This PR adds 'Tab' and 'Shift+Tab' for item navigation

In general, users with heavy keyboard experience expect:

- Pressing 'Tab' should navigate to the next item.
- Pressing 'Shift + Tab' combo to navigate in the reverse direction.

After playing with examples, I don't see major issues with this implementation.

![tabnavigation](https://user-images.githubusercontent.com/21135812/219269421-e7e64b77-7071-4a01-903b-fff71b36dc92.gif)
