### PR TITLE
feat: export individual components to allow for tree shaking

### DIFF
--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -24,5 +24,6 @@
   },
   "devDependencies": {
     "@types/react": "18.0.15"
-  }
+  },
+  "sideEffects": false
 }

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -831,8 +831,19 @@ const pkg = Object.assign(Command, {
   Empty,
   Loading,
 })
+
 export { useCmdk as useCommandState }
 export { pkg as Command }
+
+export { Command as CommandRoot }
+export { List as CommandList }
+export { Item as CommandItem }
+export { Input as CommandInput }
+export { Group as CommandGroup }
+export { Separator as CommandSeparator }
+export { Dialog as CommandDialog }
+export { Empty as CommandEmpty }
+export { Loading as CommandLoading }
 
 /**
  *


### PR DESCRIPTION
I love this library, but I'm using it in a Chakra UI project and I don't need to extra weight of the radix ui dialog (9.5kb)

By exporting all individual components everything except Dialog can be imported, allowing bundlers to treeshake unused code and dependencies.