### PR TITLE
Fix controlled item value

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -182,7 +182,8 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
         } else if (key === 'value') {
           if (propsRef.current?.value !== undefined) {
             // If controlled, just call the callback instead of updating state internally
-            propsRef.current.onValueChange?.(value as string)
+            const newValue = (value ?? '') as string
+            propsRef.current.onValueChange?.(newValue)
             return
             // opts is a boolean referring to whether it should NOT be scrolled into view
           } else if (!opts) {

--- a/test/props.test.ts
+++ b/test/props.test.ts
@@ -21,6 +21,15 @@ test.describe('props', async () => {
     await expect(page.locator(`[cmdk-item][aria-selected]`)).toHaveAttribute('data-value', 'anteater')
   })
 
+  test('keep controlled value if empty results', async ({ page }) => {
+    await page.goto('/props')
+    await expect(page.locator(`[data-testid=value]`)).toHaveText('ant')
+    await page.locator(`[cmdk-input]`).fill('d')
+    await expect(page.locator(`[data-testid=value]`)).toHaveText('')
+    await page.locator(`[cmdk-input]`).fill('ant')
+    await expect(page.locator(`[data-testid=value]`)).toHaveText('ant')
+  })
+
   test('controlled search', async ({ page }) => {
     await page.goto('/props')
     await expect(page.locator(`[cmdk-item][aria-selected]`)).toHaveAttribute('data-value', 'ant')


### PR DESCRIPTION
In the code it is checked if `value !== undefined` to call `onValueChange`, so when no item is selected the value is `undefined` making the `Command` uncontrolled.

Closes #106