### PR TITLE
fix: keep focus on the initial value

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -133,7 +133,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     /** Value of the search query. */
     search: '',
     /** Currently selected item value. */
-    value: '',
+    value: props.value ?? '',
     filtered: {
       /** The count of all visible items. */
       count: 0,
@@ -250,14 +250,15 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
           ids.current.delete(id)
           allItems.current.delete(id)
           state.current.filtered.items.delete(id)
+          const selectedItem = getSelectedItem()
 
           // Batch this, multiple items could be removed in one pass
           schedule(4, () => {
             filterItems()
 
-            // The item removed could have been the selected one,
+            // The item removed have been the selected one,
             // so selection should be moved to the first
-            selectFirstItem()
+            if (selectedItem?.getAttribute('id') === id) selectFirstItem()
 
             store.emit()
           })
@@ -409,7 +410,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
   /** Getters */
 
   function getSelectedItem() {
-    return ref.current.querySelector(`${ITEM_SELECTOR}[aria-selected="true"]`)
+    return ref.current?.querySelector(`${ITEM_SELECTOR}[aria-selected="true"]`)
   }
 
   function getValidItems() {
@@ -437,8 +438,8 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
         index + change < 0
           ? items[items.length - 1]
           : index + change === items.length
-          ? items[0]
-          : items[index + change]
+            ? items[0]
+            : items[index + change]
     }
 
     if (newSelected) store.setState('value', newSelected.getAttribute(VALUE_ATTR))
@@ -592,10 +593,10 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
     props.forceMount
       ? true
       : context.filter() === false
-      ? true
-      : !state.search
-      ? true
-      : state.filtered.items.get(id) > 0,
+        ? true
+        : !state.search
+          ? true
+          : state.filtered.items.get(id) > 0,
   )
 
   React.useEffect(() => {
@@ -923,7 +924,7 @@ function mergeRefs<T = any>(refs: Array<React.MutableRefObject<T> | React.Legacy
       if (typeof ref === 'function') {
         ref(value)
       } else if (ref != null) {
-        ;(ref as React.MutableRefObject<T | null>).current = value
+        ; (ref as React.MutableRefObject<T | null>).current = value
       }
     })
   }

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -438,8 +438,8 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
         index + change < 0
           ? items[items.length - 1]
           : index + change === items.length
-            ? items[0]
-            : items[index + change]
+          ? items[0]
+          : items[index + change]
     }
 
     if (newSelected) store.setState('value', newSelected.getAttribute(VALUE_ATTR))
@@ -593,10 +593,10 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
     props.forceMount
       ? true
       : context.filter() === false
-        ? true
-        : !state.search
-          ? true
-          : state.filtered.items.get(id) > 0,
+      ? true
+      : !state.search
+      ? true
+      : state.filtered.items.get(id) > 0,
   )
 
   React.useEffect(() => {
@@ -924,7 +924,7 @@ function mergeRefs<T = any>(refs: Array<React.MutableRefObject<T> | React.Legacy
       if (typeof ref === 'function') {
         ref(value)
       } else if (ref != null) {
-        ; (ref as React.MutableRefObject<T | null>).current = value
+        ;(ref as React.MutableRefObject<T | null>).current = value
       }
     })
   }

--- a/test/pages/props.tsx
+++ b/test/pages/props.tsx
@@ -13,6 +13,7 @@ const Page = () => {
     if (router.isReady) {
       setShouldFilter(router.query.shouldFilter === 'false' ? false : true)
       setCustomFilter(router.query.customFilter === 'true' ? true : false)
+      setValue(router.query.initialValue as string ?? 'ant')
     }
   }, [router.isReady])
 
@@ -35,10 +36,10 @@ const Page = () => {
         filter={
           customFilter
             ? (item: string | undefined, search: string | undefined) => {
-                console.log(item, search)
-                if (!search || !item) return 1
-                return item.endsWith(search) ? 1 : 0
-              }
+              console.log(item, search)
+              if (!search || !item) return 1
+              return item.endsWith(search) ? 1 : 0
+            }
             : undefined
         }
       >

--- a/test/pages/props.tsx
+++ b/test/pages/props.tsx
@@ -13,7 +13,7 @@ const Page = () => {
     if (router.isReady) {
       setShouldFilter(router.query.shouldFilter === 'false' ? false : true)
       setCustomFilter(router.query.customFilter === 'true' ? true : false)
-      setValue(router.query.initialValue as string ?? 'ant')
+      setValue((router.query.initialValue as string) ?? 'ant')
     }
   }, [router.isReady])
 
@@ -36,10 +36,10 @@ const Page = () => {
         filter={
           customFilter
             ? (item: string | undefined, search: string | undefined) => {
-              console.log(item, search)
-              if (!search || !item) return 1
-              return item.endsWith(search) ? 1 : 0
-            }
+                console.log(item, search)
+                if (!search || !item) return 1
+                return item.endsWith(search) ? 1 : 0
+              }
             : undefined
         }
       >

--- a/test/props.test.ts
+++ b/test/props.test.ts
@@ -36,4 +36,9 @@ test.describe('props', async () => {
     await page.locator(`data-testid=controlledSearch`).click()
     await expect(page.locator(`[cmdk-item][aria-selected]`)).toHaveAttribute('data-value', 'anteater')
   })
+
+  test('keep focus on the provided initial value', async ({ page }) => {
+    await page.goto('/props?initialValue=anteater')
+    await expect(page.locator(`[cmdk-item][aria-selected]`)).toHaveAttribute('data-value', 'anteater')
+  })
 })


### PR DESCRIPTION
Fixes that cmdk always focus on the first item even if another item value is provided.

Closes #90 