### PR TITLE
Disable select item with mouse

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -633,7 +633,6 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
       aria-disabled={disabled || undefined}
       aria-selected={selected || undefined}
       data-selected={selected || undefined}
-      onPointerMove={disabled ? undefined : select}
       onClick={disabled ? undefined : onSelect}
     >
       {props.children}

--- a/website/styles/cmdk/framer.scss
+++ b/website/styles/cmdk/framer.scss
@@ -63,7 +63,7 @@
     transition: all 150ms ease;
     transition-property: none;
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], :hover) {
       background: var(--blue9);
       color: #ffffff;
 

--- a/website/styles/cmdk/linear.scss
+++ b/website/styles/cmdk/linear.scss
@@ -75,7 +75,7 @@
     transition-property: none;
     position: relative;
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], :hover) {
       background: var(--gray3);
 
       svg {

--- a/website/styles/cmdk/raycast.scss
+++ b/website/styles/cmdk/raycast.scss
@@ -148,7 +148,7 @@
     transition: all 150ms ease;
     transition-property: none;
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], :hover) {
       background: var(--gray4);
       color: var(--gray12);
     }

--- a/website/styles/cmdk/vercel.scss
+++ b/website/styles/cmdk/vercel.scss
@@ -66,7 +66,7 @@
     transition: all 150ms ease;
     transition-property: none;
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], :hover) {
       background: var(--grayA3);
       color: var(--gray12);
     }


### PR DESCRIPTION
As discussed in #49 keyboard-only item selection is the new default. I didn't add a prop to enable mouse selection because this can be implemented by the consumer if he wants to. What do you think? 

I think the only problem here is that the mouse selection style will break for users so would this be a breaking change?