### PR TITLE
chore: allow override props

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -501,8 +501,8 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
   return (
     <div
       ref={mergeRefs([ref, forwardedRef])}
-      {...etc}
       cmdk-root=""
+      {...etc}
       onKeyDown={(e) => {
         etc.onKeyDown?.(e)
 
@@ -626,13 +626,13 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
   return (
     <div
       ref={mergeRefs([ref, forwardedRef])}
-      {...etc}
       id={id}
       cmdk-item=""
       role="option"
       aria-disabled={disabled || undefined}
       aria-selected={selected || undefined}
       data-selected={selected || undefined}
+      {...etc}
       onPointerMove={disabled ? undefined : select}
       onClick={disabled ? undefined : onSelect}
     >
@@ -667,10 +667,10 @@ const Group = React.forwardRef<HTMLDivElement, GroupProps>((props, forwardedRef)
   return (
     <div
       ref={mergeRefs([ref, forwardedRef])}
-      {...etc}
       cmdk-group=""
       role="presentation"
       hidden={render ? undefined : true}
+      {...etc}
     >
       {heading && (
         <div ref={headingRef} cmdk-group-heading="" aria-hidden id={headingId}>
@@ -694,7 +694,7 @@ const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>((props, forwa
   const render = useCmdk((state) => !state.search)
 
   if (!alwaysRender && !render) return null
-  return <div ref={mergeRefs([ref, forwardedRef])} {...etc} cmdk-separator="" role="separator" />
+  return <div ref={mergeRefs([ref, forwardedRef])} cmdk-separator="" role="separator" {...etc} />
 })
 
 /**
@@ -723,7 +723,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forwardedRe
   return (
     <input
       ref={forwardedRef}
-      {...etc}
       cmdk-input=""
       autoComplete="off"
       autoCorrect="off"
@@ -736,6 +735,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forwardedRe
       aria-activedescendant={selectedItemId}
       id={context.inputId}
       type="text"
+      {...etc}
       value={isControlled ? props.value : search}
       onChange={(e) => {
         if (!isControlled) {
@@ -780,12 +780,12 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
   return (
     <div
       ref={mergeRefs([ref, forwardedRef])}
-      {...etc}
       cmdk-list=""
       role="listbox"
       aria-label="Suggestions"
       id={context.listId}
       aria-labelledby={context.inputId}
+      {...etc}
     >
       <div ref={height} cmdk-list-sizer="">
         {children}
@@ -823,7 +823,7 @@ const Empty = React.forwardRef<HTMLDivElement, EmptyProps>((props, forwardedRef)
   }, [])
 
   if (isFirstRender.current || !render) return null
-  return <div ref={forwardedRef} {...props} cmdk-empty="" role="presentation" />
+  return <div ref={forwardedRef} cmdk-empty="" role="presentation" {...props} />
 })
 
 /**
@@ -835,13 +835,13 @@ const Loading = React.forwardRef<HTMLDivElement, LoadingProps>((props, forwarded
   return (
     <div
       ref={forwardedRef}
-      {...etc}
       cmdk-loading=""
       role="progressbar"
       aria-valuenow={progress}
       aria-valuemin={0}
       aria-valuemax={100}
       aria-label="Loading..."
+      {...etc}
     >
       <div aria-hidden>{children}</div>
     </div>


### PR DESCRIPTION
Allow consumers to override component's props. Some examples where it can be useful:

- Provide a custom `aria-label` to `Command.Loading`
- Although this is not the main use case of this lib, makes possible to override `aria-expanded` to build an accessible combobox where the list opens when the focus is on the input or after typing.