### PR TITLE
chore: use forceMount from group as fallback

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -661,7 +661,7 @@ const Group = React.forwardRef<HTMLDivElement, GroupProps>((props, forwardedRef)
 
   useValue(id, ref, [props.value, props.heading, headingRef])
 
-  const contextValue = React.useMemo(() => ({ id, forceMount }), [])
+  const contextValue = React.useMemo(() => ({ id, forceMount }), [forceMount])
   const inner = <GroupContext.Provider value={contextValue}>{children}</GroupContext.Provider>
 
   return (

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -591,7 +591,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
   const forceMount = propsRef.current?.forceMount ?? groupContext?.forceMount
 
   useLayoutEffect(() => {
-    return context.item(id, groupContext.id)
+    return context.item(id, groupContext?.id)
   }, [])
 
   const value = useValue(id, ref, [props.value, props.children, ref])

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -588,7 +588,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
   const groupContext = React.useContext(GroupContext)
   const context = useCommand()
   const propsRef = useAsRef(props)
-  const forceMount = propsRef.current.forceMount ?? groupContext.forceMount
+  const forceMount = propsRef.current?.forceMount ?? groupContext?.forceMount
 
   useLayoutEffect(() => {
     return context.item(id, groupContext.id)


### PR DESCRIPTION
Currently, to force the rendering of the group and its items we must use `forceMount` on `Command.Group` and all of its `Command.Item` manually. 

This PR adds the group's `forceMount` as a fallback for items so it only needs to be defined in `Command.Group`.