### PR TITLE
Add `data-disabled` to `Item` and recommend using data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ To scroll item into view earlier near the edges of the viewport, use scroll-padd
 }
 ```
 
-### Item `[cmdk-item]` `[aria-disabled?]` `[aria-selected?]`
+### Item `[cmdk-item]` `[data-disabled?]` `[data-selected?]`
 
 Item that becomes active on pointer enter. You should provide a unique `value` for each item, but it will be automatically inferred from the `.textContent`.
 

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -632,6 +632,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
       role="option"
       aria-disabled={disabled || undefined}
       aria-selected={selected || undefined}
+      data-disabled={disabled || undefined}
       data-selected={selected || undefined}
       onPointerMove={disabled ? undefined : select}
       onClick={disabled ? undefined : onSelect}

--- a/website/styles/cmdk/framer.scss
+++ b/website/styles/cmdk/framer.scss
@@ -63,7 +63,7 @@
     transition: all 150ms ease;
     transition-property: none;
 
-    &[aria-selected='true'] {
+    &[data-selected='true'] {
       background: var(--blue9);
       color: #ffffff;
 
@@ -72,7 +72,7 @@
       }
     }
 
-    &[aria-disabled='true'] {
+    &[data-disabled='true'] {
       color: var(--gray8);
       cursor: not-allowed;
     }

--- a/website/styles/cmdk/linear.scss
+++ b/website/styles/cmdk/linear.scss
@@ -75,7 +75,7 @@
     transition-property: none;
     position: relative;
 
-    &[aria-selected='true'] {
+    &[data-selected='true'] {
       background: var(--gray3);
 
       svg {
@@ -93,7 +93,7 @@
       }
     }
 
-    &[aria-disabled='true'] {
+    &[data-disabled='true'] {
       color: var(--gray8);
       cursor: not-allowed;
     }

--- a/website/styles/cmdk/raycast.scss
+++ b/website/styles/cmdk/raycast.scss
@@ -148,12 +148,12 @@
     transition: all 150ms ease;
     transition-property: none;
 
-    &[aria-selected='true'] {
+    &[data-selected='true'] {
       background: var(--gray4);
       color: var(--gray12);
     }
 
-    &[aria-disabled='true'] {
+    &[data-disabled='true'] {
       color: var(--gray8);
       cursor: not-allowed;
     }

--- a/website/styles/cmdk/vercel.scss
+++ b/website/styles/cmdk/vercel.scss
@@ -66,12 +66,12 @@
     transition: all 150ms ease;
     transition-property: none;
 
-    &[aria-selected='true'] {
+    &[data-selected='true'] {
       background: var(--grayA3);
       color: var(--gray12);
     }
 
-    &[aria-disabled='true'] {
+    &[data-disabled='true'] {
       color: var(--gray8);
       cursor: not-allowed;
     }


### PR DESCRIPTION
Following what was said in #77 I believe it should also apply to `aria-disabled` and for consistency. This PR adds:

- Add `data-disabled` attribute to `Item` part
- Update docs and examples to recommend using `data-attributes` instead of `aria-attributes`