### PR TITLE
feat: add default value prop

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -75,6 +75,10 @@ type CommandProps = Children &
      */
     filter?: (value: string, search: string) => number
     /**
+      * Optional default item value when it is initially rendered.
+      */
+    defaultValue?: string
+    /**
      * Optional controlled state of the selected command menu item.
      */
     value?: string
@@ -137,7 +141,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     /** Value of the search query. */
     search: '',
     /** Currently selected item value. */
-    value: props.value ?? '',
+    value: props.value ?? props.defaultValue.toLowerCase() ?? '',
     filtered: {
       /** The count of all visible items. */
       count: 0,

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -141,7 +141,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     /** Value of the search query. */
     search: '',
     /** Currently selected item value. */
-    value: props.value ?? props.defaultValue.toLowerCase() ?? '',
+    value: props.value ?? props.defaultValue?.toLowerCase() ?? '',
     filtered: {
       /** The count of all visible items. */
       count: 0,

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -75,8 +75,8 @@ type CommandProps = Children &
      */
     filter?: (value: string, search: string) => number
     /**
-      * Optional default item value when it is initially rendered.
-      */
+     * Optional default item value when it is initially rendered.
+     */
     defaultValue?: string
     /**
      * Optional controlled state of the selected command menu item.

--- a/website/components/cmdk/raycast.tsx
+++ b/website/components/cmdk/raycast.tsx
@@ -16,7 +16,7 @@ export function RaycastCMDK() {
 
   return (
     <div className="raycast">
-      <Command value={value} onValueChange={(v) => setValue(v)}>
+      <Command defaultValue="Slack">
         <div cmdk-raycast-top-shine="" />
         <Command.Input ref={inputRef} autoFocus placeholder="Search for apps and commands..." />
         <hr cmdk-raycast-loader="" />

--- a/website/components/cmdk/raycast.tsx
+++ b/website/components/cmdk/raycast.tsx
@@ -16,7 +16,7 @@ export function RaycastCMDK() {
 
   return (
     <div className="raycast">
-      <Command defaultValue="Slack">
+      <Command value={value} onValueChange={(v) => setValue(v)}>
         <div cmdk-raycast-top-shine="" />
         <Command.Input ref={inputRef} autoFocus placeholder="Search for apps and commands..." />
         <hr cmdk-raycast-loader="" />


### PR DESCRIPTION
Closes #115 

In this PR, I added the optional prop of default value, which, when passing the item's value to the default value, makes this item active. Otherwise, the function of activating the first item on the list continues.

## BEFORE
```tsx
const [value, setValue] = React.useState('apple')

return (
  <Command value={value} onValueChange={setValue}>
    <Command.Input />
    <Command.List>
      <Command.Item>Orange</Command.Item>
      <Command.Item>Apple</Command.Item>
    </Command.List>
  </Command>
)
```

## NOW
```tsx
return (
  <Command defaultValue="Apple">
    <Command.Input />
    <Command.List>
      <Command.Item>Orange</Command.Item>
      <Command.Item>Apple</Command.Item>
    </Command.List>
  </Command>
)
```