### PR TITLE
Add failing test for numeric inputs

### DIFF
--- a/test/numeric.test.ts
+++ b/test/numeric.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('behavior for numeric values', async () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/numeric')
+  })
+
+  test('items filter correctly on numeric inputs', async ({ page }) => {
+    const input = page.locator(`[cmdk-input]`)
+    await input.type('112')
+    const removed = page.locator(`[cmdk-item][data-value="removed"]`)
+    const remains = page.locator(`[cmdk-item][data-value="foo.bar112.value"]`)
+    await expect(removed).toHaveCount(0)
+    await expect(remains).toHaveCount(1)
+  })
+
+  test('items filter correctly on non-numeric inputs', async ({ page }) => {
+    const input = page.locator(`[cmdk-input]`)
+    await input.type('bar')
+    const removed = page.locator(`[cmdk-item][data-value="removed"]`)
+    const remains = page.locator(`[cmdk-item][data-value="foo.bar112.value"]`)
+    await expect(removed).toHaveCount(0)
+    await expect(remains).toHaveCount(1)
+  })
+})

--- a/test/pages/numeric.tsx
+++ b/test/pages/numeric.tsx
@@ -1,0 +1,22 @@
+import { Command } from 'cmdk'
+
+const Page = () => {
+  return (
+    <div>
+      <Command className="root">
+        <Command.Input placeholder="Search…" className="input" />
+        <Command.List className="list">
+          <Command.Empty className="empty">No results.</Command.Empty>
+          <Command.Item value="removed" className="item">
+            To be removed
+          </Command.Item>
+          <Command.Item value="foo.bar112.value" className="item">
+            Not to be removed
+          </Command.Item>
+        </Command.List>
+      </Command>
+    </div>
+  )
+}
+
+export default Page


### PR DESCRIPTION
Hi all!

Due to an inconsistency between the main branch and the latest released version of `command-score`, alphanumeric strings do not get scored correctly.

This PR adds a failing test for this behaviour.

I also created https://github.com/superhuman/command-score/issues/16.