### PR TITLE
Revert "Fix: `selected` and `disabled` state"

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -633,10 +633,10 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
       id={id}
       cmdk-item=""
       role="option"
-      aria-disabled={disabled ?? undefined}
-      aria-selected={selected ?? undefined}
-      data-disabled={disabled ?? undefined}
-      data-selected={selected ?? undefined}
+      aria-disabled={disabled || undefined}
+      aria-selected={selected || undefined}
+      data-disabled={disabled || undefined}
+      data-selected={selected || undefined}
       onPointerMove={disabled ? undefined : select}
       onClick={disabled ? undefined : onSelect}
     >


### PR DESCRIPTION
Reverts pacocoursey/cmdk#84

This doesn't actually make any sense, oops. If `disable` or `selected` is false, we'd output `undefined`.