### PR TITLE
fix: only scroll into view on first render and via keyboard

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -173,10 +173,17 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     if (value !== undefined) {
       const v = value.trim().toLowerCase()
       state.current.value = v
-      schedule(6, scrollSelectedIntoView)
       store.emit()
     }
   }, [value])
+
+  useLayoutEffect(() => {
+    let isFirstRender = true
+    if (isFirstRender) {
+      schedule(6, scrollSelectedIntoView)
+      isFirstRender = false
+    }
+  }, [])
 
   const store: Store = React.useMemo(() => {
     return {
@@ -197,15 +204,16 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
           sort()
           schedule(1, selectFirstItem)
         } else if (key === 'value') {
+          // opts is a boolean referring to whether it should NOT be scrolled into view
+          if (!opts) {
+            // Scroll the selected item into view
+            schedule(5, scrollSelectedIntoView)
+          }
           if (propsRef.current?.value !== undefined) {
             // If controlled, just call the callback instead of updating state internally
             const newValue = (value ?? '') as string
             propsRef.current.onValueChange?.(newValue)
             return
-            // opts is a boolean referring to whether it should NOT be scrolled into view
-          } else if (!opts) {
-            // Scroll the selected item into view
-            schedule(5, scrollSelectedIntoView)
           }
         }
 


### PR DESCRIPTION
Fix some issues with scroll into view when item value is changed

- Scroll into view only on first render in uncontrolled/controlled mode (fixes the issue where the item is scrolled with pointer events, if controlled)
- Scroll into view if `defaultValue` prop is provided