### PR TITLE
fix: add exports field for support esm

### DIFF
--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -8,6 +8,13 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "scripts": {
     "prepublishOnly": "cp ../README.md . && pnpm build",
     "postpublish": "rm README.md",


### PR DESCRIPTION
Related PR: https://github.com/radix-ui/primitives/pull/2130

For TypeScript and Node.js to support the ECMAScript Module, the exports field must be specified.
It is my understanding that the module field currently specified in package.json is a 'non-standard' field supported by webpack/rollup.
(https://webpack.js.org/guides/author-libraries/#final-steps)
