### PR TITLE
Fix forceMount too many rerenders

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -595,8 +595,10 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
   const forceMount = propsRef.current?.forceMount ?? groupContext?.forceMount
 
   useLayoutEffect(() => {
-    return context.item(id, groupContext?.id)
-  }, [])
+    if (!forceMount) {
+      return context.item(id, groupContext?.id)
+    }
+  }, [forceMount])
 
   const value = useValue(id, ref, [props.value, props.children, ref])
 
@@ -624,7 +626,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
 
   if (!render) return null
 
-  const { disabled, value: _, onSelect: __, ...etc } = props
+  const { disabled, value: _, onSelect: __, forceMount: ___, ...etc } = props
 
   return (
     <div


### PR DESCRIPTION
When using the following code to add a "Create action", React throws `Maximum update depth exceeded` error because `filtered.count` will loop update between 0 and 1

```jsx
const search = useCommandState((state) => state.search)
const isEmpty = useCommandState((state) => state.filtered.count === 0)

return isEmpty ? <Command.Item forceMount>Create {search}</Command.Item> : null
```

To fix this the `Item` is not registered to be filtered when `forceMount` is `true`