### PR TITLE
fix: useId backward compatibility

### DIFF
--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.0.5",
+    "@radix-ui/react-id": "^1.0.1",
     "@radix-ui/react-primitive": "1.0.3"
   },
   "devDependencies": {

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -163,6 +163,17 @@ const useStore = () => React.useContext(StoreContext)
 // @ts-ignore
 const GroupContext = React.createContext<Group>(undefined)
 
+const getId = (() => {
+  let i = 0
+  return () => `${i++}`
+})()
+const useIdCompatibility = () => {
+  React.useState(getId)
+  const [id] = React.useState(getId)
+  return id
+}
+const useId = React.useId ?? useIdCompatibility
+
 const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwardedRef) => {
   const state = useLazyRef<State>(() => ({
     /** Value of the search query. */

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -2,6 +2,7 @@ import * as RadixDialog from '@radix-ui/react-dialog'
 import * as React from 'react'
 import { commandScore } from './command-score'
 import { Primitive } from '@radix-ui/react-primitive'
+import { useId } from '@radix-ui/react-id'
 
 type Children = { children?: React.ReactNode }
 type DivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>
@@ -172,7 +173,6 @@ const useIdCompatibility = () => {
   const [id] = React.useState(getId)
   return 'cmdk' + id
 }
-const useId = React.useId ?? useIdCompatibility
 
 const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwardedRef) => {
   const state = useLazyRef<State>(() => ({
@@ -207,9 +207,9 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     ...etc
   } = props
 
-  const listId = React.useId()
-  const labelId = React.useId()
-  const inputId = React.useId()
+  const listId = useId()
+  const labelId = useId()
+  const inputId = useId()
 
   const listInnerRef = React.useRef<HTMLDivElement>(null)
 
@@ -650,7 +650,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
  * the rendered item's `textContent`.
  */
 const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) => {
-  const id = React.useId()
+  const id = useId()
   const ref = React.useRef<HTMLDivElement>(null)
   const groupContext = React.useContext(GroupContext)
   const context = useCommand()
@@ -716,10 +716,10 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
  */
 const Group = React.forwardRef<HTMLDivElement, GroupProps>((props, forwardedRef) => {
   const { heading, children, forceMount, ...etc } = props
-  const id = React.useId()
+  const id = useId()
   const ref = React.useRef<HTMLDivElement>(null)
   const headingRef = React.useRef<HTMLDivElement>(null)
-  const headingId = React.useId()
+  const headingId = useId()
   const context = useCommand()
   const render = useCmdk((state) =>
     forceMount ? true : context.filter() === false ? true : !state.search ? true : state.filtered.groups.has(id),

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -170,7 +170,7 @@ const getId = (() => {
 const useIdCompatibility = () => {
   React.useState(getId)
   const [id] = React.useState(getId)
-  return id
+  return 'cmdk' + id
 }
 const useId = React.useId ?? useIdCompatibility
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: 1.0.5
         version: 1.0.5(@types/react@18.0.15)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id':
+        specifier: ^1.0.1
+        version: 1.0.1(@types/react@18.0.15)(react@18.2.0)
       '@radix-ui/react-primitive':
         specifier: 1.0.3
         version: 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.15)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
Projects not using react 18 are not able to use CMDK lib. #162 

This PR implements retro-compatibility for one of the hooks from React 18 used by the lib.