### PR TITLE
Fix bug with backspacing

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -971,8 +971,11 @@ function useValue(
           return part.trim().toLowerCase()
         }
 
-        if (typeof part === 'object' && 'current' in part && part.current) {
-          return part.current.textContent?.trim().toLowerCase()
+        if (typeof part === 'object' && 'current' in part) {
+          if (part.current) {
+            return part.current.textContent?.trim().toLowerCase()
+          }
+          return valueRef.current
         }
       }
     })()


### PR DESCRIPTION
This fixes a bug where backspacing would not properly reveal items that didn't have their `value` explicitly set.

@dschlabach identified the root cause of the issue in #172; this is just a tiny change to better retain the previously detected `value` in that function when the element no longer exists in the DOM.