### PR TITLE
add repository and homepage fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "cmdk-root",
   "private": true,
+  "repository": "github:pacocoursey/cmdk",
+  "homepage": "https://cmdk.paco.me",
   "scripts": {
     "build": "pnpm -F cmdk build",
     "dev": "pnpm -F cmdk build --watch",


### PR DESCRIPTION
This will make sites like [npm-trends](https://npmtrends.com/cmdk-vs-kbar-vs-ninja-keys-vs-react-cmdk-vs-scoutbar) provide a link to the repository and to the package homepage. [Currently both are missing](https://npmtrends.com/cmdk-vs-kbar-vs-ninja-keys-vs-react-cmdk-vs-scoutbar)

![CleanShot 2023-09-03 at 13 35 15@2x](https://github.com/pacocoursey/cmdk/assets/23618431/bb8443f6-6fc0-4e05-aef6-d65744d50d75)


It will also add the fields to the [package page on npmjs.com/package/cmdk](https://npmjs.com/package/cmdk)

![CleanShot 2023-09-03 at 13 37 32@2x](https://github.com/pacocoursey/cmdk/assets/23618431/8762567d-e2ad-4f72-87bc-c3f9388b9381)
