### PR TITLE
Fix suggestions list and loading progressbar labels

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -9,6 +9,10 @@ type LoadingProps = Children &
   DivProps & {
     /** Estimated progress of loading asynchronous options. */
     progress?: number
+    /**
+     * Accessible label for this loading progressbar. Not shown visibly.
+     */
+    label?: string
   }
 type EmptyProps = Children & DivProps & {}
 type SeparatorProps = DivProps & {
@@ -849,7 +853,7 @@ const Empty = React.forwardRef<HTMLDivElement, EmptyProps>((props, forwardedRef)
  * You should conditionally render this with `progress` while loading asynchronous items.
  */
 const Loading = React.forwardRef<HTMLDivElement, LoadingProps>((props, forwardedRef) => {
-  const { progress, children, ...etc } = props
+  const { progress, children, label = "Loading...", ...etc } = props
 
   return (
     <div
@@ -860,7 +864,7 @@ const Loading = React.forwardRef<HTMLDivElement, LoadingProps>((props, forwarded
       aria-valuenow={progress}
       aria-valuemin={0}
       aria-valuemax={100}
-      aria-label="Loading..."
+      aria-label={label}
     >
       <div aria-hidden>{children}</div>
     </div>

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -24,7 +24,13 @@ type DialogProps = RadixDialog.DialogProps &
     /** Provide a custom element the Dialog should portal into. */
     container?: HTMLElement
   }
-type ListProps = Children & DivProps & {}
+type ListProps = Children &
+  DivProps & {
+    /**
+     * Accessible label for this List of suggestions. Not shown visibly.
+     */
+    label?: string
+  }
 type ItemProps = Children &
   Omit<DivProps, 'disabled' | 'onSelect' | 'value'> & {
     /** Whether this item is currently disabled. */
@@ -767,7 +773,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forwardedRe
  * Use the `--cmdk-list-height` CSS variable to animate height based on the number of results.
  */
 const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) => {
-  const { children, ...etc } = props
+  const { children, label = "Suggestions", ...etc } = props
   const ref = React.useRef<HTMLDivElement>(null)
   const height = React.useRef<HTMLDivElement>(null)
   const context = useCommand()
@@ -797,9 +803,8 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
       {...etc}
       cmdk-list=""
       role="listbox"
-      aria-label="Suggestions"
+      aria-label={label}
       id={context.listId}
-      aria-labelledby={context.inputId}
     >
       <div ref={height} cmdk-list-sizer="">
         {children}


### PR DESCRIPTION
Fixes https://github.com/pacocoursey/cmdk/issues/196

This PR aims to improve the accessible labels of two components of the user interface.
Also, the current label are hardcoded English text. In projects that are translated to other languages, these labels need to be passed via prop so that they are translatable.

1
The suggestions list.
Currently, it is labelled via both `aria-label` and `aria-labelledby`. This is redundant as `aria-labelledby` will always override `aria-label`. Also, `aria-labelledby` points to the search input id. As a result, the list of suggestions is labeled with the term users type in the search field, which is inappropriate.
- Removes the `aria-labelledby` attribute.
- Adds a prop to pass the `aria-label` value.

2
Loading progressbar label.
Currently, it's hardcoded English text. 
- Adds a prop to pass the `aria-label` value.