### PR TITLE
fix: escape quote

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -399,7 +399,9 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     groups
       .sort((a, b) => b[1] - a[1])
       .forEach((group) => {
-        const element = listInnerRef.current.querySelector(`${GROUP_SELECTOR}[${VALUE_ATTR}="${group[0]}"]`)
+        const element = listInnerRef.current.querySelector(
+          `${GROUP_SELECTOR}[${VALUE_ATTR}="${encodeURIComponent(group[0])}"]`,
+        )
         element?.parentElement.appendChild(element)
       })
   }


### PR DESCRIPTION
resolve #222 

This commit https://github.com/pacocoursey/cmdk/commit/8aecf2d22c288872a3908ef3041a9279d5f29d60 missing another position that should escape quotes in `[data-value=...]`