### PR TITLE
chore: add more details to package.json

### DIFF
--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -43,5 +43,5 @@
   "homepage": "https://github.com/pacocoursey/cmdk#readme",
   "author": {
     "url": "https://github.com/pacocoursey"
-  },
+  }
 }

--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -32,5 +32,16 @@
   "devDependencies": {
     "@types/react": "18.0.15"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/pacocoursey/cmdk.git"
+  },
+  "bugs": {
+      "url": "https://github.com/pacocoursey/cmdk/issues"
+  },
+  "homepage": "https://github.com/pacocoursey/cmdk#readme",
+  "author": {
+      "url": "https://github.com/pacocoursey"
+  },
 }

--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -34,14 +34,14 @@
   },
   "sideEffects": false,
   "repository": {
-      "type": "git",
-      "url": "git+https://github.com/pacocoursey/cmdk.git"
+    "type": "git",
+    "url": "git+https://github.com/pacocoursey/cmdk.git"
   },
   "bugs": {
-      "url": "https://github.com/pacocoursey/cmdk/issues"
+    "url": "https://github.com/pacocoursey/cmdk/issues"
   },
   "homepage": "https://github.com/pacocoursey/cmdk#readme",
   "author": {
-      "url": "https://github.com/pacocoursey"
+    "url": "https://github.com/pacocoursey"
   },
 }


### PR DESCRIPTION
Currently, the npm package doesn't link to the repo, so it's not straightforward to access the source code when you just installed the library. Also, dependabot updates currently do not link to the project.

| npm | dependabot |
| - | - |
| ![image](https://github.com/pacocoursey/cmdk/assets/4947671/e2edaad7-4a5c-486c-839d-e74c9b0cec7f)  | ![image](https://github.com/pacocoursey/cmdk/assets/4947671/4418797a-a758-4c0b-9d50-89bf084ab7c9) |

This is caused by missing properties in `cmdk`'s `package.json`. After adding these properties, the npm page would look something like this, providing easy access to the package's source.

![image](https://github.com/pacocoursey/cmdk/assets/4947671/5955aeb6-4a34-4ebf-80d8-711efd706ef2)


**Question:**
- Should "Homepage" point to this repo or https://cmdk.paco.me?