### PR TITLE
feat: export defaultFilter

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -923,6 +923,7 @@ const pkg = Object.assign(Command, {
 
 export { useCmdk as useCommandState }
 export { pkg as Command }
+export { defaultFilter }
 
 export { Command as CommandRoot }
 export { List as CommandList }


### PR DESCRIPTION
Exporting the `defaultFilter` would allow users to re-use the internal command-score implementation with their own wrapping function. For example, we might want to transform one or more of the arguments before calling it.

```js
import { Command, defaultFilter } from 'cmdx'

<Command 
  filter={(value, search, keywords) => 
    defaultFilter(value, search.replaceAll(' ', ''), keywords)
  }
>
  ...
</Command>
```