### PR TITLE
fix(store): Make `getValidItems()` handle missing `CommandList`

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -482,7 +482,8 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
   }
 
   function getValidItems() {
-    return Array.from(listInnerRef.current?.querySelectorAll(VALID_ITEM_SELECTOR) || [])
+    const elements = listInnerRef.current?.querySelectorAll(VALID_ITEM_SELECTOR);
+    return Array.from(elements ?? []);
   }
 
   /** Setters */


### PR DESCRIPTION
If one's using `CommandItem` without a `CommandList` wrapper (just like in [shadcn/ui's `Combobox` example](https://ui.shadcn.com/docs/components/combobox)), the `querySelectorAll()` returns `void`.  This leads to a `TypeError` at runtime when called with `Array.from(void 0)`.

This should handle this use case.