### PR TITLE
[Accessibility] Use id instead of children

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -133,6 +133,7 @@ type Context = {
 type State = {
   search: string
   value: string
+  selectedItemId?: string
   filtered: { count: number; items: Map<string, number>; groups: Set<string> }
 }
 type Store = {
@@ -180,6 +181,8 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     search: '',
     /** Currently selected item value. */
     value: props.value ?? props.defaultValue ?? '',
+    /** Currently selected item id. */
+    selectedItemId: undefined,
     filtered: {
       /** The count of all visible items. */
       count: 0,
@@ -247,6 +250,18 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
           sort()
           schedule(1, selectFirstItem)
         } else if (key === 'value') {
+          // Force focus input or root so accessibility works
+          if (document.activeElement.hasAttribute('cmdk-input') || document.activeElement.hasAttribute('cmdk-root')) {
+            const input = document.getElementById(inputId)
+            if (input) input.focus()
+            else document.getElementById(listId)?.focus()
+          }
+
+          schedule(7, () => {
+            state.current.selectedItemId = getSelectedItem()?.id
+            store.emit()
+          })
+
           // opts is a boolean referring to whether it should NOT be scrolled into view
           if (!opts) {
             // Scroll the selected item into view
@@ -779,15 +794,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forwardedRe
   const isControlled = props.value != null
   const store = useStore()
   const search = useCmdk((state) => state.search)
-  const value = useCmdk((state) => state.value)
+  const selectedItemId = useCmdk((state) => state.selectedItemId)
   const context = useCommand()
-
-  const selectedItemId = React.useMemo(() => {
-    const item = context.listInnerRef.current?.querySelector(
-      `${ITEM_SELECTOR}[${VALUE_ATTR}="${encodeURIComponent(value)}"]`,
-    )
-    return item?.getAttribute('id')
-  }, [])
 
   React.useEffect(() => {
     if (props.value != null) {
@@ -831,6 +839,7 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
   const { children, label = 'Suggestions', ...etc } = props
   const ref = React.useRef<HTMLDivElement>(null)
   const height = React.useRef<HTMLDivElement>(null)
+  const selectedItemId = useCmdk((state) => state.selectedItemId)
   const context = useCommand()
 
   React.useEffect(() => {
@@ -858,6 +867,8 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
       {...etc}
       cmdk-list=""
       role="listbox"
+      tabIndex={-1}
+      aria-activedescendant={selectedItemId}
       aria-label={label}
       id={context.listId}
     >


### PR DESCRIPTION
Closes #253 

Values were not being read aloud when selected with mouse, arrow keys, etc.
This is because:
1. The `aria-activedescendant` was not being updated
2. The element with the `aria-activedescendant` must be focused to read the value it references aloud

Finding the selected item was previously done using a querySelector and encodeUri which is bad because if children are used instead of a string, this will not serialize well (As well as spaces, special characters, etc.). The new approach is more robust and uses the actual ID in the dom.

The focus issue is solved by changing the focus back to the command input, or outer list container when the value is updated.