### PR TITLE
fix(context): read disablePointerSelection from propsRef

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -122,7 +122,7 @@ type Context = {
   group: (id: string) => () => void
   filter: () => boolean
   label: string
-  disablePointerSelection: boolean
+  shouldDisablePointerSelection: () => boolean
   // Ids
   listId: string
   labelId: string
@@ -342,7 +342,9 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
         return propsRef.current.shouldFilter
       },
       label: label || props['aria-label'],
-      disablePointerSelection,
+      shouldDisablePointerSelection: () => {
+        return propsRef.current.disablePointerSelection
+      },
       listId,
       inputId,
       labelId,
@@ -704,7 +706,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
       aria-selected={Boolean(selected)}
       data-disabled={Boolean(disabled)}
       data-selected={Boolean(selected)}
-      onPointerMove={disabled || context.disablePointerSelection ? undefined : select}
+      onPointerMove={disabled || context.shouldDisablePointerSelection() ? undefined : select}
       onClick={disabled ? undefined : onSelect}
     >
       {props.children}

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -122,7 +122,7 @@ type Context = {
   group: (id: string) => () => void
   filter: () => boolean
   label: string
-  shouldDisablePointerSelection: () => boolean
+  getDisablePointerSelection: () => boolean
   // Ids
   listId: string
   labelId: string
@@ -342,7 +342,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
         return propsRef.current.shouldFilter
       },
       label: label || props['aria-label'],
-      shouldDisablePointerSelection: () => {
+      getDisablePointerSelection: () => {
         return propsRef.current.disablePointerSelection
       },
       listId,
@@ -706,7 +706,7 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>((props, forwardedRef) =
       aria-selected={Boolean(selected)}
       data-disabled={Boolean(disabled)}
       data-selected={Boolean(selected)}
-      onPointerMove={disabled || context.shouldDisablePointerSelection() ? undefined : select}
+      onPointerMove={disabled || context.getDisablePointerSelection() ? undefined : select}
       onClick={disabled ? undefined : onSelect}
     >
       {props.children}


### PR DESCRIPTION
**Issue:**
At present, updating the value `disablePointerSelection` prop _after_ the component has rendered once does not propagate the updated value to the underlying code. `context` has outdated value of `disablePointerSelection` since the dependency array for `useMemo` is empty.

**Proposed Fix:**
Similar to other places in current codebase, use the `propsRef` which carries updated props instead of directly referencing `disablePointerSelection` prop.

