### PR TITLE
feat: allow react v19 as peer dep

### DIFF
--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -22,8 +22,8 @@
     "dev": "tsup src --watch"
   },
   "peerDependencies": {
-    "react": "^18 || ^19",
-    "react-dom": "^18 || ^19"
+    "react": "^18 || ^19 || ^19.0.0-rc",
+    "react-dom": "^18 || ^19 || ^19.0.0-rc"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.1",

--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -22,8 +22,8 @@
     "dev": "tsup src --watch"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.1",


### PR DESCRIPTION
I get the following warning from pnpm after upgrading to NextJS v15 (released today), which installs react 19 RC

React 19 is technically still in RC stage, but since a stable version of a major Metaframework is installing it, it's a sign that it's ready for production use and will now be used by many projects.

```
│ ├─┬ cmdk 1.0.0
│ │ ├── ✕ unmet peer react@^18.0.0: found 19.0.0-rc-65a56d0e-20241020
│ │ ├── ✕ unmet peer react-dom@^18.0.0: found 19.0.0-rc-65a56d0e-20241020
```

P.S.: thank you so much for this package! it has been a big source of inspiration for my project (radix UI for AI chat interfaces)