### PR TITLE
fix useCmdk return type

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -1015,7 +1015,7 @@ function mergeRefs<T = any>(refs: Array<React.MutableRefObject<T> | React.Legacy
 }
 
 /** Run a selector against the store state. */
-function useCmdk<T = any>(selector: (state: State) => T) {
+function useCmdk<T = any>(selector: (state: State) => T): T {
   const store = useStore()
   const cb = () => selector(store.snapshot())
   return useSyncExternalStore(store.subscribe, cb, cb)


### PR DESCRIPTION
I think this is related to the most recent changes in 1.0.4. The return type of `useCommandState` became `any` which caused lint failures in our application. I assume it was a mistake.

**before this change**
![image](https://github.com/user-attachments/assets/2c702b0e-53af-4625-9794-19b29b4c6397)

**after this change**
![CleanShot 2024-11-08 at 13 11 37@2x](https://github.com/user-attachments/assets/3004695c-1aef-49a1-b7d9-eca4ecaa105a)

