### PR TITLE
Use React's useSyncExternalStore

### DIFF
--- a/cmdk/package.json
+++ b/cmdk/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-id": "^1.1.0",
-    "@radix-ui/react-primitive": "^2.0.0",
-    "use-sync-external-store": "^1.2.2"
+    "@radix-ui/react-primitive": "^2.0.0"
   },
   "devDependencies": {
     "@types/react": "18.0.15"

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -5,7 +5,6 @@ import * as React from 'react'
 import { commandScore } from './command-score'
 import { Primitive } from '@radix-ui/react-primitive'
 import { useId } from '@radix-ui/react-id'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 type Children = { children?: React.ReactNode }
 type DivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>
@@ -1018,7 +1017,7 @@ function mergeRefs<T = any>(refs: Array<React.MutableRefObject<T> | React.Legacy
 function useCmdk<T = any>(selector: (state: State) => T): T {
   const store = useStore()
   const cb = () => selector(store.snapshot())
-  return useSyncExternalStore(store.subscribe, cb, cb)
+  return React.useSyncExternalStore(store.subscribe, cb, cb)
 }
 
 function useValue(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       react-dom:
         specifier: ^18 || ^19 || ^19.0.0-rc
         version: 18.2.0(react@18.2.0)
-      use-sync-external-store:
-        specifier: ^1.2.2
-        version: 1.2.2(react@18.2.0)
     devDependencies:
       '@types/react':
         specifier: 18.0.15
@@ -4337,14 +4334,6 @@ packages:
       detect-node-es: 1.1.0
       react: 18.2.0
       tslib: 2.6.2
-    dev: false
-
-  /use-sync-external-store@1.2.2(react@18.2.0):
-    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
     dev: false
 
   /v8-compile-cache@2.3.0:


### PR DESCRIPTION
React added support for `useSyncExternalStore` as a stable feature in [version 18](https://react.dev/blog/2022/03/29/react-v18). Our `peerDependencies` requires at least version 18 of React, so all users will have `useSyncExternalStore` available without the need for a shim.

Apart from being a cleanup and reducing the number of dependencies, this fixes a problem I encountered when trying to bundle React to be a standalone module.