### PR TITLE
Fix unintended double triggering of key bindings during IME composition

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -576,7 +576,13 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
       onKeyDown={(e) => {
         etc.onKeyDown?.(e)
 
-        if (!e.defaultPrevented) {
+        // Check if IME composition is finished before triggering key binds
+        // This prevents unwanted triggering while user is still inputting text with IME
+        // e.keyCode === 229 is for the CJK IME with Legacy Browser [https://w3c.github.io/uievents/#determine-keydown-keyup-keyCode]
+        // isComposing is for the CJK IME with Modern Browser [https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent/isComposing]
+        const isComposing = e.nativeEvent.isComposing || e.keyCode === 229
+
+        if (!e.defaultPrevented || !isComposing) {
           switch (e.key) {
             case 'n':
             case 'j': {
@@ -615,18 +621,12 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
               break
             }
             case 'Enter': {
-              // Check if IME composition is finished before triggering onSelect
-              // This prevents unwanted triggering while user is still inputting text with IME
-              // e.keyCode === 229 is for the Japanese IME and Safari.
-              // isComposing does not work with Japanese IME and Safari combination.
-              if (!e.nativeEvent.isComposing && e.keyCode !== 229) {
-                // Trigger item onSelect
-                e.preventDefault()
-                const item = getSelectedItem()
-                if (item) {
-                  const event = new Event(SELECT_EVENT)
-                  item.dispatchEvent(event)
-                }
+              // Trigger item onSelect
+              e.preventDefault()
+              const item = getSelectedItem()
+              if (item) {
+                const event = new Event(SELECT_EVENT)
+                item.dispatchEvent(event)
               }
             }
           }

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -585,52 +585,54 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
         // isComposing is for the CJK IME with Modern Browser [https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent/isComposing]
         const isComposing = e.nativeEvent.isComposing || e.keyCode === 229
 
-        if (!e.defaultPrevented || !isComposing) {
-          switch (e.key) {
-            case 'n':
-            case 'j': {
-              // vim keybind down
-              if (vimBindings && e.ctrlKey) {
-                next(e)
-              }
-              break
-            }
-            case 'ArrowDown': {
+        if (e.defaultPrevented || isComposing) {
+          return
+        }
+
+        switch (e.key) {
+          case 'n':
+          case 'j': {
+            // vim keybind down
+            if (vimBindings && e.ctrlKey) {
               next(e)
-              break
             }
-            case 'p':
-            case 'k': {
-              // vim keybind up
-              if (vimBindings && e.ctrlKey) {
-                prev(e)
-              }
-              break
-            }
-            case 'ArrowUp': {
+            break
+          }
+          case 'ArrowDown': {
+            next(e)
+            break
+          }
+          case 'p':
+          case 'k': {
+            // vim keybind up
+            if (vimBindings && e.ctrlKey) {
               prev(e)
-              break
             }
-            case 'Home': {
-              // First item
-              e.preventDefault()
-              updateSelectedToIndex(0)
-              break
-            }
-            case 'End': {
-              // Last item
-              e.preventDefault()
-              last()
-              break
-            }
-            case 'Enter': {
-              // Trigger item onSelect
-              e.preventDefault()
-              const item = getSelectedItem()
-              if (item) {
-                const event = new Event(SELECT_EVENT)
-                item.dispatchEvent(event)
-              }
+            break
+          }
+          case 'ArrowUp': {
+            prev(e)
+            break
+          }
+          case 'Home': {
+            // First item
+            e.preventDefault()
+            updateSelectedToIndex(0)
+            break
+          }
+          case 'End': {
+            // Last item
+            e.preventDefault()
+            last()
+            break
+          }
+          case 'Enter': {
+            // Trigger item onSelect
+            e.preventDefault()
+            const item = getSelectedItem()
+            if (item) {
+              const event = new Event(SELECT_EVENT)
+              item.dispatchEvent(event)
             }
           }
         }


### PR DESCRIPTION
### Description:

This PR addresses a bug where key bindings were unintentionally triggered twice during IME (Input Method Editor) composition. The issue occurred because IME input events were not properly handled, leading to duplicate keybinding activations in certain scenarios.

### Problem:

When using an IME for text input (e.g., for languages like Korean, Japanese, or Chinese), the composition process generates intermediate key events. In the current implementation, these events were mistakenly causing the key binding logic to execute twice—once for the actual input and once for the intermediate composition event.