### PR TITLE
Fix wrong score calculation with leading/trailing white space on search string

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -358,7 +358,9 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
 
   function score(value: string, keywords?: string[]) {
     const filter = propsRef.current?.filter ?? defaultFilter
-    return value ? filter(value, state.current.search?.trim(), keywords) : 0
+    const search = state.current.search ?? ''
+    const sanitizedSearch = search.replace(/\s+/g, ' ').trim()
+    return value ? filter(value, sanitizedSearch, keywords) : 0
   }
 
   /** Sorts items by score, and groups by highest item score. */


### PR DESCRIPTION
## Description:
I'm using `cmdk` as a multi-selector with the option to create custom entries that are not listed. To do this, I'm simply rendering a `Command.Item` with the exact same key/value as the search string.

The problem is that, when the search contains a trailing space, e.g. "Test ", the score function doesn't match any items (likely because it's trying to match the exact string with the trailing space). What ends up happening is that all options get a score of 0 and what gets rendered is the `<CommandEmpty/>` component, even though I have an Item with the exact same value as the search. 

## Solution
This pull request includes a change to the `cmdk/src/index.tsx` file to fix the scoring function by trimming the search string before applying the filter. This ensures that any leading or trailing whitespace in the search string does not affect the scoring.

* [`cmdk/src/index.tsx`](diffhunk://#diff-cbf5f58af38192892b7ed4c065895274c0a610020f38ac13ea9ed344856ce839L361-R361): Modified the `score` function to trim the search string before passing it to the filter function.

Current Behavior:
https://github.com/user-attachments/assets/397823b4-461f-4e69-9f92-a6a2368234f0

After fix:
https://github.com/user-attachments/assets/09e5792c-a57f-4a49-84bd-073de7274247

### Edit:
The score algorithm also does not work well with whitespaces in-between words, so instead of just trimming the start/end, I'm applying a complete string sanitization to remove multiple space characters between words and then trimming the ends.

I know REGEXes are not the most performant option but since an item is supposed to be a menu item and not an entire essay, it gets the job done and there's no performance hit at all ([~53 steps, 65μs](https://regex101.com/r/mG9bQ5/1)).