### PR TITLE
fix: set dialog title and description when provided to avoid Radix-ui error

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -880,12 +880,13 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
  * Renders the command menu in a Radix Dialog.
  */
 const Dialog = React.forwardRef<HTMLDivElement, DialogProps>((props, forwardedRef) => {
-  const { open, onOpenChange, overlayClassName, contentClassName, container, ...etc } = props
+  const { open, onOpenChange, overlayClassName, contentClassName, container, title, ...etc } = props
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Portal container={container}>
         <RadixDialog.Overlay cmdk-overlay="" className={overlayClassName} />
         <RadixDialog.Content aria-label={props.label} cmdk-dialog="" className={contentClassName}>
+          {title && <RadixDialog.Title hidden>{title}</RadixDialog.Title>}
           <Command ref={forwardedRef} {...etc} />
         </RadixDialog.Content>
       </RadixDialog.Portal>

--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -33,6 +33,8 @@ type DialogProps = RadixDialog.DialogProps &
     contentClassName?: string
     /** Provide a custom element the Dialog should portal into. */
     container?: HTMLElement
+    /** Provide a hidden description text to the Dialog content */
+    description?: string
   }
 type ListProps = Children &
   DivProps & {
@@ -880,13 +882,14 @@ const List = React.forwardRef<HTMLDivElement, ListProps>((props, forwardedRef) =
  * Renders the command menu in a Radix Dialog.
  */
 const Dialog = React.forwardRef<HTMLDivElement, DialogProps>((props, forwardedRef) => {
-  const { open, onOpenChange, overlayClassName, contentClassName, container, title, ...etc } = props
+  const { open, onOpenChange, overlayClassName, contentClassName, container, title, description, ...etc } = props
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Portal container={container}>
         <RadixDialog.Overlay cmdk-overlay="" className={overlayClassName} />
         <RadixDialog.Content aria-label={props.label} cmdk-dialog="" className={contentClassName}>
           {title && <RadixDialog.Title hidden>{title}</RadixDialog.Title>}
+          {description && <RadixDialog.Description hidden>{description}</RadixDialog.Description>}
           <Command ref={forwardedRef} {...etc} />
         </RadixDialog.Content>
       </RadixDialog.Portal>


### PR DESCRIPTION
resolve https://github.com/pacocoursey/cmdk/issues/337

# Overview

`Content` of radix-ui/react-dialog requires [`Title`](https://www.radix-ui.com/primitives/docs/components/dialog#title) to set its accessible title, otherwise it provides the following error: "`DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users." Also, we would like to set accessible description with [`Description`](https://www.radix-ui.com/primitives/docs/components/dialog#description).

In https://github.com/pacocoursey/cmdk/issues/337, they showed some workaround to avoid that error, but I prefer the library itself provides a way to solve the issue.

This change will set the title component if `title` and `description` properties of `Command.Dialog` is set.

# Reproduction

I create a [reproduction](https://github.com/tnyo43/cmdk-fix-no-title-error-reproduce) to see how it works.



| main branch (https://github.com/pacocoursey/cmdk/commit/fb4ea04e9ec211777fbb39c6104e3c5f2ee107d2)                             | fix/no-title-error branch                                            |
| ---------------------------------------- | -------------------------------------------------------------------- |
|![with-main](https://github.com/user-attachments/assets/0a6c3a9a-d60a-4f20-ba08-e8635385ec0d)|![with-fix-no-title-error](https://github.com/user-attachments/assets/8fca914c-ae01-4cd1-b672-acf926663a15)|
