### PR TITLE
feat: expose role prop on Input component for improved accessibility

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -785,7 +785,7 @@ const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>((props, forwa
  * All props are forwarded to the underyling `input` element.
  */
 const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forwardedRef) => {
-  const { onValueChange, ...etc } = props
+  const { onValueChange, role = "combobox", ...etc } = props
   const isControlled = props.value != null
   const store = useStore()
   const search = useCmdk((state) => state.search)
@@ -807,7 +807,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forwardedRe
       autoCorrect="off"
       spellCheck={false}
       aria-autocomplete="list"
-      role="combobox"
+      role={role}
       aria-expanded={true}
       aria-controls={context.listId}
       aria-labelledby={context.labelId}


### PR DESCRIPTION
### 📝 Summary

This PR adds support for an optional `role` prop on the `Input` component. Previously, the `role` was hardcoded to `"combobox"`, which limited the component's accessibility (a11y) use cases.

### 🚫 The Problem

The `Input` component is versatile and can be used in various contexts, not just as a combobox. A common use case is as a standalone search bar. For optimal accessibility, a dedicated search input should have `role="search"`. The hardcoded `"combobox"` role made this impossible without resorting to non-standard overrides.

### ✅ The Solution

This change modifies the `Input` component to:

1. Accept a new optional `role` prop.

2. Default to `role="combobox"` to maintain full backward compatibility for all existing users. The default behavior of the component is unchanged.

3. Pass the prop through to the underlying `<input>` element.

### 🧪 Usage Example

Users can now correctly define the role based on their specific context:

**As a Combobox (Default, unchanged)**

```jsx
<Command.Input placeholder="Search..." />
// Renders with: <input role="combobox" ... />
```

**As a Searchbox**

```jsx
<Command.Input role="searchbox" placeholder="Search the site..." />
// Renders with: <input role="searchbox" ... />
```

### ♿ Accessibility Impact

This change significantly improves the library's flexibility regarding accessibility. Screen readers and other assistive technologies can now better understand the purpose of the input based on its defined role, leading to a more accurate experience for users.

- `role="combobox"`: Correctly indicates the input controls a popup list (the command menu).

- `role="searchbox"`: Correctly indicates the input is for performing searches, which is a very common use case for this component.

### 🔄 Backwards Compatibility

This change is **fully backwards compatible**. The `role` prop is optional and defaults to the original value of `"combobox"`. No existing code should break or require modification.